### PR TITLE
remove forced reload when switching ammotypes

### DIFF
--- a/lua/cw/shared/ammotypes/am_flechetterounds.lua
+++ b/lua/cw/shared/ammotypes/am_flechetterounds.lua
@@ -13,12 +13,10 @@ end
 
 function att:attachFunc()
 	self.Shots = 20
-	self:unloadWeapon()
 end
 
 function att:detachFunc()
 	self.Shots = self.Shots_Orig
-	self:unloadWeapon()
 end
 
 CustomizableWeaponry:registerAttachment(att)

--- a/lua/cw/shared/ammotypes/am_magnum.lua
+++ b/lua/cw/shared/ammotypes/am_magnum.lua
@@ -11,12 +11,8 @@ if CLIENT then
 	att.description = {}
 end
 
-function att:attachFunc()
-	self:unloadWeapon()
-end
+function att:attachFunc() end
 
-function att:detachFunc()
-	self:unloadWeapon()
-end
+function att:detachFunc() end
 
 CustomizableWeaponry:registerAttachment(att)

--- a/lua/cw/shared/ammotypes/am_matchgrade.lua
+++ b/lua/cw/shared/ammotypes/am_matchgrade.lua
@@ -10,12 +10,8 @@ if CLIENT then
 	att.description = {}
 end
 
-function att:attachFunc()
-	self:unloadWeapon()
-end
+function att:attachFunc() end
 
-function att:detachFunc()
-	self:unloadWeapon()
-end
+function att:detachFunc() end
 
 CustomizableWeaponry:registerAttachment(att)

--- a/lua/cw/shared/ammotypes/am_slugrounds.lua
+++ b/lua/cw/shared/ammotypes/am_slugrounds.lua
@@ -15,13 +15,11 @@ end
 function att:attachFunc()
 	self.Shots = 1
 	self.ClumpSpread = nil
-	self:unloadWeapon()
 end
 
 function att:detachFunc()
 	self.Shots = self.Shots_Orig
 	self.ClumpSpread = self.ClumpSpread_Orig
-	self:unloadWeapon()
 end
 
 CustomizableWeaponry:registerAttachment(att)


### PR DESCRIPTION
probably does the trick, can't test. presumably works for all cw weapon packs.